### PR TITLE
Bug occured when run riscof test

### DIFF
--- a/rtl/core/cellrv32_uart.sv
+++ b/rtl/core/cellrv32_uart.sv
@@ -492,7 +492,7 @@ module cellrv32_uart #(
                 if ((ctrl.enable == 1'b1) && (ctrl.sim_mode == 1'b1) && 
                     (wren == 1'b1) && (addr == uart_id_rtx_addr_c)) begin // UART simulation mode
                     /* print lowest byte as ASCII char */
-                    char_v = int'(data_i);
+                    char_v = int'(data_i[7:0]);
                     // check out of range
                     if (char_v >= 128) begin
                         char_v = 0;


### PR DESCRIPTION
**Describe the bug** 
Unable to decode STDOUT result in bug when run riscof test :

``` test='/mnt/d/VLSI/cellrv32_riscof/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sext.h-01.S'
test='/mnt/d/VLSI/cellrv32_riscof/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh1add-01.S'
test='/mnt/d/VLSI/cellrv32_riscof/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh2add-01.S'
test='/mnt/d/VLSI/cellrv32_riscof/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/sh3add-01.S'
test='/mnt/d/VLSI/cellrv32_riscof/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/xnor-01.S'
test='/mnt/d/VLSI/cellrv32_riscof/riscv-arch-test/riscv-test-suite/rv32i_m/B/src/zext.h_32-01.S'
 WARNING | Unable to decode STDOUT for launched subprocess. Output written to:/mnt/d/VLSI/cellrv32_riscof/stdout.log
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.10.4/lib/python3.10/site-packages/riscof/utils.py", line 247, in run
    logger.debug(out.decode(fmt))
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 5416: invalid start byte
```